### PR TITLE
Add an interceptor to append access token to requests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -360,11 +360,6 @@
         "tsickle": "0.21.6"
       }
     },
-    "@auth0/angular-jwt": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@auth0/angular-jwt/-/angular-jwt-1.0.0-beta.9.tgz",
-      "integrity": "sha1-ZQIsNJ7ck97DMS+TO5VccZ6GKmI="
-    },
     "@compodoc/compodoc": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@compodoc/compodoc/-/compodoc-1.0.4.tgz",
@@ -738,6 +733,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "angular2-jwt": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/angular2-jwt/-/angular2-jwt-0.2.3.tgz",
+      "integrity": "sha1-VO/do87tuoX2o3sWXyKsIrit8CE="
     },
     "ansi-escapes": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser": "^4.4.6",
     "@angular/platform-browser-dynamic": "^4.4.6",
     "@angular/router": "^4.4.6",
-    "@auth0/angular-jwt": "^1.0.0-beta.9",
+    "angular2-jwt": "^0.2.3",
     "codemirror": "^5.31.0",
     "concurrently": "^3.5.0",
     "core-js": "^2.5.1",

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -23,6 +23,7 @@ import {
 import {AboutUsComponent} from './components/about-us/about-us.component'
 import {IndexComponent} from './components/index/index.component'
 import {LoginComponent} from './components/login/login.component'
+import {LogoutComponent} from './components/logout/logout.component'
 import {RegisterComponent} from './components/register/register.component'
 
 const routes: Routes = [
@@ -30,6 +31,9 @@ const routes: Routes = [
   {path: 'index', component: IndexComponent},
   {path: 'aboutus', component: AboutUsComponent},
   {path: 'login', component: LoginComponent},
+  {path: 'logout/:message', component: LogoutComponent},
+  {path: 'logout/:message/:error', component: LogoutComponent},
+  {path: 'logout', component: LogoutComponent},
   {path: 'register', component: RegisterComponent}
 ]
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -34,12 +34,14 @@ import {FileExComponent} from './components/file-ex/file-ex.component'
 import {HeaderComponent} from './components/header/header.component'
 import {IndexComponent} from './components/index/index.component'
 import {LoginComponent} from './components/login/login.component'
+import {LogoutComponent} from './components/logout/logout.component'
 import {OutputComponent} from './components/output/output.component'
 import {RegisterComponent} from './components/register/register.component'
 import {ToolbarComponent} from './components/toolbar/toolbar.component'
 //SERVICES
 import {AuthService} from './services/auth.service'
 import {CookieService} from './services/cookie.service'
+import {LoginService} from './services/login.service'
 //INTERCEPTORS
 import {OAuthInterceptor} from './interceptors/oauth.interceptor'
 
@@ -51,6 +53,7 @@ import {OAuthInterceptor} from './interceptors/oauth.interceptor'
     HeaderComponent,
     IndexComponent,
     LoginComponent,
+    LogoutComponent,
     OutputComponent,
     RegisterComponent,
     ToolbarComponent
@@ -67,7 +70,8 @@ import {OAuthInterceptor} from './interceptors/oauth.interceptor'
   providers: [
     {provide: HTTP_INTERCEPTORS, useClass: OAuthInterceptor, multi: true},
     AuthService,
-    CookieService
+    CookieService,
+    LoginService
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -42,6 +42,7 @@ import {ToolbarComponent} from './components/toolbar/toolbar.component'
 import {AuthService} from './services/auth.service'
 import {CookieService} from './services/cookie.service'
 import {LoginService} from './services/login.service'
+import {LogoutService} from './services/logout.service'
 //INTERCEPTORS
 import {OAuthInterceptor} from './interceptors/oauth.interceptor'
 
@@ -71,7 +72,8 @@ import {OAuthInterceptor} from './interceptors/oauth.interceptor'
     {provide: HTTP_INTERCEPTORS, useClass: OAuthInterceptor, multi: true},
     AuthService,
     CookieService,
-    LoginService
+    LoginService,
+    LogoutService
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -17,12 +17,16 @@
 import {NgModule} from '@angular/core'
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations'
 import {BrowserModule} from '@angular/platform-browser'
-import {HttpClientModule} from '@angular/common/http'
+import {
+  HTTP_INTERCEPTORS,
+  HttpClientModule
+} from '@angular/common/http'
+import {HttpModule} from '@angular/http'
 
 import {CodemirrorModule} from 'ng2-codemirror'
-import {JwtModule} from '@auth0/angular-jwt'
 import {SuiModule} from 'ng2-semantic-ui'
 
+//COMPONENTS
 import {AppComponent} from './app.component'
 import {AppRoutingModule} from './app-routing.module'
 import {AboutUsComponent} from './components/about-us/about-us.component'
@@ -33,11 +37,11 @@ import {LoginComponent} from './components/login/login.component'
 import {OutputComponent} from './components/output/output.component'
 import {RegisterComponent} from './components/register/register.component'
 import {ToolbarComponent} from './components/toolbar/toolbar.component'
-
-// Using an arrow function here will throw Angular AOT errors
-export function tokenGetter() {
-  return localStorage.getItem('access_token')
-}
+//SERVICES
+import {AuthService} from './services/auth.service'
+import {CookieService} from './services/cookie.service'
+//INTERCEPTORS
+import {OAuthInterceptor} from './interceptors/oauth.interceptor'
 
 @NgModule({
   declarations: [
@@ -57,15 +61,14 @@ export function tokenGetter() {
     BrowserModule,
     CodemirrorModule,
     HttpClientModule,
-    JwtModule.forRoot({
-      config: {
-        tokenGetter,
-        whitelistedDomains: ['localhost:8181']
-      }
-    }),
+    HttpModule,
     SuiModule
   ],
-  providers: [],
+  providers: [
+    {provide: HTTP_INTERCEPTORS, useClass: OAuthInterceptor, multi: true},
+    AuthService,
+    CookieService
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/frontend/src/app/components/logout/logout.component.html
+++ b/frontend/src/app/components/logout/logout.component.html
@@ -5,7 +5,7 @@
     <div class="ui header huge">
       {{message}}.
     </div>
-    <div *ngIf="error" id="error" class="ui mini negative message">
+    <div *ngIf="error != 'undefined' && error != 'null'" id="error" class="ui mini negative message">
       {{error}}!
     </div>
     <div id="button-wrapper">

--- a/frontend/src/app/components/logout/logout.component.html
+++ b/frontend/src/app/components/logout/logout.component.html
@@ -1,0 +1,16 @@
+<div id="container">
+  <div class="ui center aligned icon header">
+    <i class="circular hand spock icon"></i><br>
+    You've been logged out.
+    <div class="ui header huge">
+      {{message}}.
+    </div>
+    <div *ngIf="error" id="error" class="ui mini negative message">
+      {{error}}!
+    </div>
+    <div id="button-wrapper">
+      <button routerLink="/" class="ui big button">Go home</button>
+      <button routerLink="/login" class="ui big button">Log back in</button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/logout/logout.component.sass
+++ b/frontend/src/app/components/logout/logout.component.sass
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import base
+
+#container
+  margin-top: 5rem
+  font-size: +2em
+
+  #error
+    display: flex
+    justify-content: center
+
+  #button-wrapper
+    display: flex
+    justify-content: space-around

--- a/frontend/src/app/components/logout/logout.component.spec.ts
+++ b/frontend/src/app/components/logout/logout.component.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  async,
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing'
+
+import {LogoutComponent} from './logout.component'
+
+describe('LogoutComponent', () => {
+  let component: LogoutComponent
+  let fixture: ComponentFixture<LogoutComponent>
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LogoutComponent ]
+    })
+    .compileComponents()
+  }))
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LogoutComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+})

--- a/frontend/src/app/components/logout/logout.component.spec.ts
+++ b/frontend/src/app/components/logout/logout.component.spec.ts
@@ -28,9 +28,9 @@ describe('LogoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LogoutComponent ]
+      declarations: [LogoutComponent]
     })
-    .compileComponents()
+      .compileComponents()
   }))
 
   beforeEach(() => {

--- a/frontend/src/app/components/logout/logout.component.ts
+++ b/frontend/src/app/components/logout/logout.component.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component} from '@angular/core'
+import {ActivatedRoute, Params} from '@angular/router'
+
+@Component({
+  selector: 'app-logout',
+  templateUrl: './logout.component.html',
+  styleUrls: ['./logout.component.sass']
+})
+export class LogoutComponent {
+
+  message: string
+  error: string
+
+  constructor(route: ActivatedRoute) {
+    this.message = route.snapshot.params.message || 'Come back soon'
+    this.error = route.snapshot.params.error
+  }
+
+}

--- a/frontend/src/app/components/logout/logout.component.ts
+++ b/frontend/src/app/components/logout/logout.component.ts
@@ -28,7 +28,10 @@ export class LogoutComponent {
   error: string
 
   constructor(route: ActivatedRoute) {
-    this.message = route.snapshot.params.message || 'Come back soon'
+    this.message = route.snapshot.params.message
+    if (this.message == 'null' || this.message == 'undefined') {
+      this.message = 'Come back soon'
+    }
     this.error = route.snapshot.params.error
   }
 

--- a/frontend/src/app/interceptors/oauth.interceptor.ts
+++ b/frontend/src/app/interceptors/oauth.interceptor.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable} from '@angular/core'
+import {
+  HttpInterceptor,
+  HttpHandler,
+  HttpHeaders,
+  HttpRequest,
+  HttpEvent,
+  HttpResponse,
+  HttpErrorResponse
+} from '@angular/common/http'
+import {Observable} from 'rxjs/Observable'
+
+import {AuthService} from '../services/auth.service'
+
+/**
+ * Adds an OAuth Bearer header on all requests made using HttpClient
+ * module as long as the access token retrieved is not null.
+ * If an access token is expired and a refresh token is present,
+ * new access and refresh tokens are retrieved and updated locally.
+ */
+@Injectable()
+export class OAuthInterceptor implements HttpInterceptor {
+
+  access_token: string
+  refresh_token: string
+
+  constructor(private auth: AuthService) {
+    let tokens = auth.getSavedTokens()
+    this.access_token = tokens.access_token
+    this.refresh_token = tokens.refresh_token
+  }
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const duplicate = req.clone({
+      headers: req.headers.set('Authorization', `Bearer ${this.access_token}`)
+    })
+
+    if (this.access_token == null || this.auth.isTokenExpired(this.access_token)) {
+      if (this.refresh_token == null || this.auth.isTokenExpired(this.refresh_token)) {
+        // TODO: Logout
+      }
+      let value: any = null
+      // TODO: Check if "remember me" is checked and call this function
+      // accordingly
+      this.auth.getTokensUsingRefreshToken()
+        .subscribe(
+          data => {
+            value = duplicate
+          },
+          err => {
+            // TODO: Logout
+          }
+        )
+      return next.handle(value)
+    }
+    return next.handle(duplicate)
+  }
+
+  success(req: HttpRequest<any>, next: HttpHandler) {
+
+
+  }
+
+}

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  TestBed,
+  inject
+} from '@angular/core/testing'
+import {HttpModule} from '@angular/http'
+
+import {AuthService} from './auth.service'
+import {CookieService} from './cookie.service'
+
+describe('AuthService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      providers: [
+        AuthService,
+        CookieService
+      ]
+    })
+  })
+
+  it('should be created', inject([AuthService], (service: AuthService) => {
+    expect(service).toBeTruthy()
+  }))
+})

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -30,12 +30,12 @@ import {environment} from '../../environments/environment'
 @Injectable()
 export class AuthService {
 
-  jwtHelper = new JwtHelper()
+  private jwtHelper = new JwtHelper()
 
   constructor(
     private cookie: CookieService,
     private http: Http
-  ) { }
+  ) {}
 
   /**
    * Retrieve access and refresh tokens from server

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable} from '@angular/core'
+import {
+  Http,
+  Headers
+} from '@angular/http'
+import {Observable} from 'rxjs/Observable'
+import 'rxjs/add/operator/map'
+
+import {JwtHelper} from 'angular2-jwt'
+
+import {CookieService} from './cookie.service'
+import {environment} from '../../environments/environment'
+
+@Injectable()
+export class AuthService {
+
+  jwtHelper = new JwtHelper()
+
+  constructor(
+    private cookie: CookieService,
+    private http: Http
+  ) { }
+
+  /**
+   * Retrieve access and refresh tokens from server
+   * using user credentials.
+   * @param username Username entered by user.
+   * @param password Password entered by user.
+   */
+  public getTokens(username: string, password: string) {
+    let headers = new Headers({
+      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+      'Authorization': `Basic ${btoa(environment.clientId + ':')}`
+    })
+    let content = `username=${encodeURIComponent(username)}`
+      + `&password=${encodeURIComponent(password)}&grant_type=password`
+    return this.http.post('/api/oauth/token', content, {headers})
+      .map(data => data.json())
+  }
+
+  /**
+   * Retrieve access and refresh tokens from server
+   * using the refresh token.
+   */
+  public getTokensUsingRefreshToken() {
+    let refresh_token = this.getSavedTokens().refresh_token
+    let headers = new Headers({
+      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+      'Authorization': `Basic ${btoa(environment.clientId + ':')}`
+    })
+    let content = `refresh_token=${refresh_token}&grant_type=refresh_token`
+    return this.http.post('/api/oauth/token', content, {headers})
+      .map(data => data.json())
+  }
+
+  public updateTokens(access_token: string, refresh_token?: string) {
+    if (access_token !== null && access_token !== undefined) {
+      this.saveToken('access_token', access_token)
+    }
+    if (refresh_token !== null && refresh_token !== undefined) {
+      this.saveToken('refresh_token', refresh_token)
+    }
+  }
+
+  /**
+   * Save token in a cookie with the same expiration date as that of the token.
+   * @param key Cookie key.
+   * @param token Access or refresh token.
+   */
+  private saveToken(key: string, token: string) {
+    let decodedToken = this.jwtHelper.decodeToken(token)
+    let date = new Date(0)
+    date.setUTCSeconds(decodedToken.exp)
+    this.cookie.set(key, token, date)
+  }
+
+  /**
+   * Get saved tokens from cookies.
+   * @returns {access_token, refresh_token} an object of access and refresh tokens.
+   */
+  public getSavedTokens(): {access_token, refresh_token} {
+    let access_token = this.cookie.get('access_token')
+    let refresh_token = this.cookie.get('refresh_token')
+    return {access_token, refresh_token}
+  }
+
+  public isTokenExpired(token: string): boolean {
+    return this.jwtHelper.isTokenExpired(token)
+  }
+
+  public deleteTokens() {
+    for (let token of ['access', 'refresh']) {
+      this.cookie.delete(token + '_token')
+    }
+  }
+
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {Injectable} from '@angular/core'
 import {
   Http,
   Headers
 } from '@angular/http'
+import {Injectable} from '@angular/core'
 import {Observable} from 'rxjs/Observable'
 import 'rxjs/add/operator/map'
 

--- a/frontend/src/app/services/cookie.service.spec.ts
+++ b/frontend/src/app/services/cookie.service.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import {TestBed, inject} from '@angular/core/testing'
+
+import {CookieService} from './cookie.service'
+
+describe('CookieService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CookieService]
+    })
+  })
+
+  it('should be created', inject([CookieService], (service: CookieService) => {
+    expect(service).toBeTruthy()
+  }))
+
+  it('should set the cookie', inject([CookieService], (service: CookieService) => {
+    service.set('test1', 'value')
+    service.set('test2', 'value')
+    service.set('test3', 'value')
+    let cookies = document.cookie
+    let expected = 'test1=value; test2=value; test3=value'
+    expect(cookies).toBe(expected)
+  }))
+
+  it('should get the cookie value', inject([CookieService], (service: CookieService) => {
+    service.set('test1', 'value')
+    let cookieValue = service.get('test1')
+    let expected = 'value'
+    expect(cookieValue).toBe(expected)
+  }))
+
+  it('should get all the cookies', inject([CookieService], (service: CookieService) => {
+    service.set('test1', 'value')
+    service.set('test2', 'value')
+    service.set('test3', 'value')
+    let cookies = service.getAll().join(';')
+    let expected = 'test1=value; test2=value; test3=value'
+    expect(cookies).toBe(expected)
+  }))
+
+  it('should delete a cookie', inject([CookieService], (service: CookieService) => {
+    service.set('test1', 'value')
+    service.delete('test1')
+    let cookies = service.get('test1')
+    let expected = null
+    expect(cookies).toBe(expected)
+  }))
+
+  it('should delete all the cookies', inject([CookieService], (service: CookieService) => {
+    service.set('test1', 'value')
+    service.set('test2', 'value')
+    service.set('test3', 'value')
+    service.deleteAll()
+    let cookies = document.cookie
+    let expected = ''
+    expect(cookies).toBe(expected)
+  }))
+})

--- a/frontend/src/app/services/cookie.service.spec.ts
+++ b/frontend/src/app/services/cookie.service.spec.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
- import {TestBed, inject} from '@angular/core/testing'
+import {
+  TestBed,
+  inject
+} from '@angular/core/testing'
 
 import {CookieService} from './cookie.service'
 

--- a/frontend/src/app/services/cookie.service.ts
+++ b/frontend/src/app/services/cookie.service.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable} from '@angular/core'
+
+@Injectable()
+export class CookieService {
+
+  constructor() { }
+
+  /**
+   * Save a cookie.
+   * @param name Cookie name.
+   * @param value Cookie value.
+   * @param expires (Optional) Cookie expiry datetime.
+   * @param path (Optional) Cookie path.
+   */
+  public set(name: string, value: string, expires?: Date, path?: string) {
+    let cookie = `${name}=${value}`
+    if (expires != null && expires != undefined) {
+      cookie += `;expires=${expires.toUTCString()}`
+    }
+    if (path != null && path != undefined) {
+      cookie += `;path=${path}`
+    }
+    document.cookie = cookie
+  }
+
+  /**
+   * Get a cookie.
+   * @param name Cookie name.
+   * @returns a cookie as a string.
+   */
+  public get(name: string): string {
+    let cookies = this.getAll()
+    let cookieVal = null
+    for (let cookie of cookies) {
+      let currentCookie = cookie.split('=')
+      if (currentCookie[0].trim() == name) {
+        cookieVal = currentCookie[1]
+        break
+      }
+    }
+    return cookieVal
+  }
+
+  /**
+   * Get all the cookies.
+   * @returns a string array of all cookie "name=value" pairs
+   */
+  public getAll(): string[] {
+    return document.cookie.split(';')
+  }
+
+  /**
+   * Delete a cookie.
+   * @param name Cookie name.
+   */
+  public delete(name: string) {
+    let date = new Date(0)
+    let cookie = `${name}=;expires=${date.toUTCString()}`
+    document.cookie = cookie
+  }
+
+  /**
+   * Delete all the cookies.
+   */
+  public deleteAll() {
+    let cookies = this.getAll()
+    for (let cookie of cookies) {
+      let cookieName = cookie.split('=')[0]
+      this.delete(cookieName)
+    }
+  }
+
+}

--- a/frontend/src/app/services/cookie.service.ts
+++ b/frontend/src/app/services/cookie.service.ts
@@ -19,7 +19,7 @@ import {Injectable} from '@angular/core'
 @Injectable()
 export class CookieService {
 
-  constructor() { }
+  constructor() {}
 
   /**
    * Save a cookie.

--- a/frontend/src/app/services/login.service.spec.ts
+++ b/frontend/src/app/services/login.service.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  TestBed,
+  inject
+} from '@angular/core/testing'
+import {HttpClientModule} from '@angular/common/http'
+import {Router} from '@angular/router'
+
+import {LoginService} from './login.service'
+
+class MockRouter {
+  navigate = jasmine.createSpy('navigate')
+}
+
+describe('LoginService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule],
+      providers: [
+        LoginService,
+        {provide: Router, useClass: MockRouter}
+      ]
+    })
+  })
+
+  it('should be created', inject([LoginService], (service: LoginService, router: Router) => {
+    expect(service).toBeTruthy()
+  }))
+})

--- a/frontend/src/app/services/login.service.spec.ts
+++ b/frontend/src/app/services/login.service.spec.ts
@@ -19,26 +19,18 @@ import {
   inject
 } from '@angular/core/testing'
 import {HttpClientModule} from '@angular/common/http'
-import {Router} from '@angular/router'
 
 import {LoginService} from './login.service'
-
-class MockRouter {
-  navigate = jasmine.createSpy('navigate')
-}
 
 describe('LoginService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientModule],
-      providers: [
-        LoginService,
-        {provide: Router, useClass: MockRouter}
-      ]
+      providers: [LoginService]
     })
   })
 
-  it('should be created', inject([LoginService], (service: LoginService, router: Router) => {
+  it('should be created', inject([LoginService], (service: LoginService) => {
     expect(service).toBeTruthy()
   }))
 })

--- a/frontend/src/app/services/login.service.ts
+++ b/frontend/src/app/services/login.service.ts
@@ -16,7 +16,6 @@
 
 import {HttpClient} from '@angular/common/http'
 import {Injectable} from '@angular/core'
-import {Router} from '@angular/router'
 
 import {LogoutComponent} from '../components/logout/logout.component'
 
@@ -24,26 +23,7 @@ import {LogoutComponent} from '../components/logout/logout.component'
 export class LoginService {
 
   constructor(
-    private http: HttpClient,
-    private router: Router
-  ) { }
-
-  logout() {
-    this.http.get('/api/destroy').subscribe(
-      data => {
-        let params = {}
-        if (data.hasOwnProperty('message')) {
-          params['message'] = data['message']
-        }
-        if (data.hasOwnProperty('error')) {
-          params['error'] = data['error']
-        }
-        this.router.navigate(['/logout', params])
-      },
-      err => {
-        throw err
-      }
-    )
-  }
+    private http: HttpClient
+  ) {}
 
 }

--- a/frontend/src/app/services/login.service.ts
+++ b/frontend/src/app/services/login.service.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {HttpClient} from '@angular/common/http'
+import {Injectable} from '@angular/core'
+import {Router} from '@angular/router'
+
+import {LogoutComponent} from '../components/logout/logout.component'
+
+@Injectable()
+export class LoginService {
+
+  constructor(
+    private http: HttpClient,
+    private router: Router
+  ) { }
+
+  logout() {
+    this.http.get('/api/destroy').subscribe(
+      data => {
+        let params = {}
+        if (data.hasOwnProperty('message')) {
+          params['message'] = data['message']
+        }
+        if (data.hasOwnProperty('error')) {
+          params['error'] = data['error']
+        }
+        this.router.navigate(['/logout', params])
+      },
+      err => {
+        throw err
+      }
+    )
+  }
+
+}

--- a/frontend/src/app/services/logout.service.spec.ts
+++ b/frontend/src/app/services/logout.service.spec.ts
@@ -21,6 +21,7 @@ import {
 import {HttpModule} from '@angular/http'
 import {Router} from '@angular/router'
 
+import {AuthService} from './auth.service'
 import {LogoutService} from './logout.service'
 
 class MockRouter {
@@ -32,6 +33,7 @@ describe('LogoutService', () => {
     TestBed.configureTestingModule({
       imports: [HttpModule],
       providers: [
+        AuthService,
         LogoutService,
         {provide: Router, useClass: MockRouter}
       ]

--- a/frontend/src/app/services/logout.service.spec.ts
+++ b/frontend/src/app/services/logout.service.spec.ts
@@ -22,6 +22,7 @@ import {HttpModule} from '@angular/http'
 import {Router} from '@angular/router'
 
 import {AuthService} from './auth.service'
+import {CookieService} from './cookie.service'
 import {LogoutService} from './logout.service'
 
 class MockRouter {
@@ -34,6 +35,7 @@ describe('LogoutService', () => {
       imports: [HttpModule],
       providers: [
         AuthService,
+        CookieService,
         LogoutService,
         {provide: Router, useClass: MockRouter}
       ]

--- a/frontend/src/app/services/logout.service.spec.ts
+++ b/frontend/src/app/services/logout.service.spec.ts
@@ -14,26 +14,31 @@
  * limitations under the License.
  */
 
-@import base
+import {
+  TestBed,
+  inject
+} from '@angular/core/testing'
+import {HttpModule} from '@angular/http'
+import {Router} from '@angular/router'
 
-#container
-  margin-top: 5rem
-  font-size: 2em
+import {LogoutService} from './logout.service'
 
-  .header
-    word-break: break-all
+class MockRouter {
+  navigate = jasmine.createSpy('navigate')
+}
 
-  #error
-    display: flex
-    justify-content: center
-    word-break: break-all
+describe('LogoutService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      providers: [
+        LogoutService,
+        {provide: Router, useClass: MockRouter}
+      ]
+    })
+  })
 
-  #button-wrapper
-    display: flex
-    justify-content: space-around
-
-@media only screen and (max-width: 768px)
-
-  #container
-    margin-top: 3rem
-    font-size: 1em
+  it('should be created', inject([LogoutService], (service: LogoutService) => {
+    expect(service).toBeTruthy()
+  }))
+})

--- a/frontend/src/app/services/logout.service.ts
+++ b/frontend/src/app/services/logout.service.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {Http} from '@angular/http'
+import {
+  Headers,
+  Http
+} from '@angular/http'
 import {Injectable} from '@angular/core'
 import {Router} from '@angular/router'
 
@@ -30,7 +33,9 @@ export class LogoutService {
   ) {}
 
   logout(message?: string, error?: string) {
-    this.http.get('/api/destroy').subscribe(
+    let access_token = this.authService.getSavedTokens().access_token
+    let headers = new Headers({'Authorization': `Bearer ${access_token}`})
+    this.http.get('/api/destroy', {headers}).subscribe(
       data => {
         let params = {message, error}
         if (data.hasOwnProperty('message')) {

--- a/frontend/src/app/services/logout.service.ts
+++ b/frontend/src/app/services/logout.service.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Http} from '@angular/http'
+import {Injectable} from '@angular/core'
+import {Router} from '@angular/router'
+
+import {AuthService} from '../services/auth.service'
+
+@Injectable()
+export class LogoutService {
+
+  constructor(
+    private authService: AuthService,
+    private http: Http,
+    private router: Router
+  ) {}
+
+  logout(message?: string, error?: string) {
+    this.http.get('/api/destroy').subscribe(
+      data => {
+        let params = {message, error}
+        if (data.hasOwnProperty('message')) {
+          params.message = data['message']
+        }
+        if (data.hasOwnProperty('error')) {
+          params.error = data['error']
+        }
+        this.authService.deleteTokens()
+        this.router.navigate(['/logout', params])
+      },
+      err => {
+        throw err
+      }
+    )
+  }
+
+}

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -4,5 +4,6 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  clientId: 'pnc-client-webapp'
 };

--- a/server/src/main/java/org/tyit/pnc/config/AuthorizationServerConfig.java
+++ b/server/src/main/java/org/tyit/pnc/config/AuthorizationServerConfig.java
@@ -92,4 +92,10 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
             .authenticationManager(authenticationManager);
   }
 
+//  Uncomment the following to expose the "/oauth/check_token" endpoint
+//  @Override
+//  public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
+//    security.checkTokenAccess("permitAll()");
+//  }
+
 }

--- a/server/src/main/java/org/tyit/pnc/config/SecurityConfig.java
+++ b/server/src/main/java/org/tyit/pnc/config/SecurityConfig.java
@@ -63,10 +63,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-    auth.userDetailsService(userDetailsService)
-            .passwordEncoder(new ShaPasswordEncoder(encodingStrength))
-            .and().inMemoryAuthentication()
-            .withUser("guest").password("").authorities("GUEST");
+    auth
+            .userDetailsService(userDetailsService)
+            .passwordEncoder(new ShaPasswordEncoder(encodingStrength));
   }
 
   @Override

--- a/server/src/main/java/org/tyit/pnc/controller/LogoutController.java
+++ b/server/src/main/java/org/tyit/pnc/controller/LogoutController.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tyit.pnc.controller;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ * @author Yash D. Saraf <yashdsaraf@gmail.com>
+ */
+@RestController
+@RequestMapping("/destroy")
+@PreAuthorize("hasAnyAuthority('ADMIN', 'DEVELOPER', 'USER')")
+public class LogoutController {
+
+  @GetMapping
+  public Map<String, String> destroy(Principal principal) {
+//    TODO: Destroy docker session
+    Map<String, String> map = new HashMap<>();
+//    map.put("message", "2");
+//    map.put("error", "1");
+    return map;
+  }
+
+}

--- a/server/src/main/java/org/tyit/pnc/model/DeveloperDetails.java
+++ b/server/src/main/java/org/tyit/pnc/model/DeveloperDetails.java
@@ -24,8 +24,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -37,8 +35,6 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 @Table(name = "DEVELOPER_DETAILS")
-@NamedQueries({
-  @NamedQuery(name = "DeveloperDetails.findAll", query = "SELECT d FROM DeveloperDetails d")})
 public class DeveloperDetails implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/server/src/main/java/org/tyit/pnc/model/Docker.java
+++ b/server/src/main/java/org/tyit/pnc/model/Docker.java
@@ -23,8 +23,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
@@ -34,8 +32,6 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 @Table(name = "DOCKER")
-@NamedQueries({
-  @NamedQuery(name = "Docker.findAll", query = "SELECT d FROM Docker d")})
 public class Docker implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/server/src/main/java/org/tyit/pnc/model/Plugin.java
+++ b/server/src/main/java/org/tyit/pnc/model/Plugin.java
@@ -27,8 +27,6 @@ import javax.persistence.JoinTable;
 import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
@@ -41,8 +39,6 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "PLUGIN")
-@NamedQueries({
-  @NamedQuery(name = "Plugin.findAll", query = "SELECT p FROM Plugin p")})
 public class Plugin implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/server/src/main/java/org/tyit/pnc/model/Project.java
+++ b/server/src/main/java/org/tyit/pnc/model/Project.java
@@ -23,8 +23,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -35,8 +33,6 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "PROJECT")
-@NamedQueries({
-  @NamedQuery(name = "Project.findAll", query = "SELECT p FROM Project p")})
 public class Project implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/server/src/main/java/org/tyit/pnc/model/Role.java
+++ b/server/src/main/java/org/tyit/pnc/model/Role.java
@@ -24,8 +24,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -36,8 +34,6 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "ROLE")
-@NamedQueries({
-  @NamedQuery(name = "Role.findAll", query = "SELECT r FROM Role r")})
 public class Role implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/server/src/main/java/org/tyit/pnc/model/User.java
+++ b/server/src/main/java/org/tyit/pnc/model/User.java
@@ -24,14 +24,13 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 /**
@@ -39,9 +38,7 @@ import javax.validation.constraints.Size;
  * @author Yash D. Saraf <yashdsaraf@gmail.com>
  */
 @Entity
-@Table(name = "USER")
-@NamedQueries({
-  @NamedQuery(name = "User.findAll", query = "SELECT u FROM User u")})
+@Table(name = "APP_USER")
 public class User implements Serializable {
 
   private static final long serialVersionUID = 1L;
@@ -55,7 +52,7 @@ public class User implements Serializable {
   @Size(min = 1, max = 255)
   @Column(name = "NAME")
   private String name;
-  // @Pattern(regexp="[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", message="Invalid email")//if the field contains email address consider using this annotation to enforce field validation
+  @Pattern(regexp = "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", message = "Invalid email")//if the field contains email address consider using this annotation to enforce field validation
   @Basic(optional = false)
   @NotNull
   @Size(min = 1, max = 255)

--- a/server/src/main/java/org/tyit/pnc/repository/UserRepository.java
+++ b/server/src/main/java/org/tyit/pnc/repository/UserRepository.java
@@ -20,4 +20,6 @@ import org.tyit.pnc.model.User;
 
 public interface UserRepository extends CrudRepository<User, Integer> {
 
+  public User findByUsername(String username);
+
 }

--- a/server/src/main/java/org/tyit/pnc/service/AppUserDetailsService.java
+++ b/server/src/main/java/org/tyit/pnc/service/AppUserDetailsService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Yash D. Saraf, Raees R. Mulla and Sachin S. Negi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tyit.pnc.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.tyit.pnc.model.User;
+import org.tyit.pnc.repository.UserRepository;
+
+/**
+ *
+ * @author Yash D. Saraf <yashdsaraf@gmail.com>
+ */
+@Service
+public class AppUserDetailsService implements UserDetailsService {
+
+  private static final String EMPTY_PASSWORD = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+    List<GrantedAuthority> authorities = new ArrayList<>();
+
+    if (username.equalsIgnoreCase("guest")) {
+      authorities.add(new SimpleGrantedAuthority("GUEST"));
+      return new org.springframework.security.core.userdetails.User(username, EMPTY_PASSWORD, authorities);
+    }
+
+    User user = userRepository.findByUsername(username);
+
+    if (user == null) {
+      throw new UsernameNotFoundException("The username " + username + " does not exist");
+    }
+
+    user.getRoleCollection().forEach(role -> {
+      authorities.add(new SimpleGrantedAuthority(role.getRoleName()));
+    });
+
+    UserDetails userDetails = new org.springframework.security.core.userdetails.User(username, username, authorities);
+    return userDetails;
+  }
+
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -4,6 +4,7 @@ server.port = 8181
 
 spring.jpa.generate-ddl = false
 spring.jpa.hibernate.ddl-auto = create-drop
+spring.jpa.hibernate.dialect = org.hibernate.dialect.Oracle10gDialect
 spring.jpa.hibernate.use-new-id-generator-mappings = true
 #spring.jpa.properties.hibernate.show_sql = true
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -13,13 +13,13 @@ logging.level.org.hibernate.SQL = DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder = TRACE
 
 security.oauth2.resource.filter-order = 3
-security.signing-key=70529FB9747DEBB43769251139313AA71D6407F8D9F93E50BB57108772253C45
-security.encoding-strength=256
-security.realm=plug_n_code_oauth_realm
+security.signing-key = 70529FB9747DEBB43769251139313AA71D6407F8D9F93E50BB57108772253C45
+security.encoding-strength = 256
+security.realm = plug_n_code_oauth_realm
 
-security.jwt.client-id=pnc-client-webapp
-security.jwt.grant-types=password,refresh_token
-security.jwt.scopes=read,write
-security.jwt.resource-id=pnc-resource-id
-security.jwt.access-token-validity=200
-security.jwt.refresh-token-validity=600
+security.jwt.client-id = pnc-client-webapp
+security.jwt.grant-types = password,refresh_token
+security.jwt.scopes = read,write
+security.jwt.resource-id = pnc-resource-id
+security.jwt.access-token-validity = 200
+security.jwt.refresh-token-validity = 600

--- a/server/src/main/resources/application.yml.stub
+++ b/server/src/main/resources/application.yml.stub
@@ -3,7 +3,3 @@ spring:
     url: #JDBC CONNECTION STRING
     username: #DATABASE USERNAME
     password: #DATABASE PASSWORD
-  jpa:
-    properties:
-      hibernate:
-        dialect: #HIBERNATE DATABASE DIALECT CLASS


### PR DESCRIPTION
The interceptor should add the `Authorization` header with the `access_token` saved locally on each request made using `HttpClient` module.